### PR TITLE
[fix] 경로 수정

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -9,3 +9,4 @@ scrape_configs:
   - job_name: 'spring-boot'
     static_configs:
       - targets: ['172.31.10.0:8000']
+        metric_path: '/actuator/prometheus'


### PR DESCRIPTION
### ✏️ 작업 개요
프로메테우스 경로 수정

### ⛳ 작업 분류
- [x] yaml 파일 수정

### 🔨 작업 상세 내용
  1. 만약 따로 경로를 지정해주지 않으면 /metrics라는 경로로 지정되게 됩니다. 하지만 현재 스프링 부트에서는 /actuator/prometheus로 설정하였기에 그에 맞추어 수정하였습니다.

### 💡 생각해볼 문제
- 냉무
